### PR TITLE
Add accessibility support for easier acceptance tests with KIF

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
@@ -28,6 +28,8 @@
 
 @interface MLPAutoCompleteTextField : UITextField <UITableViewDataSource, UITableViewDelegate, MLPAutoCompleteSortOperationDelegate, MLPAutoCompleteFetchOperationDelegate>
 
++ (NSString *) accessibilityLabelForIndexPath:(NSIndexPath *)indexPath;
+
 @property (strong, readonly) UITableView *autoCompleteTableView;
 
 @property (strong) IBOutlet id <MLPAutoCompleteTextFieldDataSource> autoCompleteDataSource;

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -234,6 +234,11 @@ static NSString *kDefaultAutoCompleteCellIdentifier = @"_DefaultAutoCompleteCell
     return cell;
 }
 
++ (NSString *) accessibilityLabelForIndexPath:(NSIndexPath *)indexPath
+{
+    return [NSString stringWithFormat:@"{%d,%d}",indexPath.section,indexPath.row];
+}
+
 - (void)configureCell:(UITableViewCell *)cell
           atIndexPath:(NSIndexPath *)indexPath
 withAutoCompleteString:(NSString *)string
@@ -276,7 +281,7 @@ withAutoCompleteString:(NSString *)string
         [cell.textLabel setFont:[UIFont fontWithName:self.font.fontName size:self.autoCompleteFontSize]];
     }
     
-    cell.accessibilityLabel = [NSString stringWithFormat:@"{%d,%d}",indexPath.section,indexPath.row];
+    cell.accessibilityLabel = [[self class] accessibilityLabelForIndexPath:indexPath];
     
     if(self.autoCompleteTableCellTextColor){
         [cell.textLabel setTextColor:self.autoCompleteTableCellTextColor];


### PR DESCRIPTION
I added an accessibilityLabel for each cell, which is a NSString representation of the NSIndexPath. 
This makes it easier to do acceptance tests with KIF for apps that use the component and maybe in the future to write acceptance tests for the component itself. 
I tried using the KIF built-in methods to select a row in a UITableView but in this particular case it didn't work. 
If this PR is merged, it will be enough to write:

<code>
[tester tapViewWithAccessibilityLabel:[MLPAutoCompleteTextField accessibilityLabelForIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]];
</code>
