### PR TITLE
Using built-in options to handle string comparison and also fixing a crash when dealing with strings containing diacritics

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -248,8 +248,7 @@ withAutoCompleteString:(NSString *)string
     if(self.applyBoldEffectToAutoCompleteSuggestions){
         BOOL attributedTextSupport = [cell.textLabel respondsToSelector:@selector(setAttributedText:)];
         NSAssert(attributedTextSupport, @"Attributed strings on UILabels are  not supported before iOS 6.0");
-        NSRange boldedRange = [[string lowercaseString]
-                               rangeOfString:[self.text lowercaseString]];
+        NSRange boldedRange = [string rangeOfString:self.text options:NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch];
         boldedString = [self boldedString:string withRange:boldedRange];
     }
     


### PR DESCRIPTION
There's no need to call <code>lowercaseString</code> if we can use <code>NSStringCompareOptions</code> instead.
Moreover, this also fixes a crash when dealing with strings containing diacritics.
