### PR TITLE
New property: `shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows`

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
@@ -44,6 +44,7 @@
 @property (assign) BOOL showAutoCompleteTableWhenEditingBegins; //only applies for drop down style autocomplete tables.
 @property (assign) BOOL disableAutoCompleteTableUserInteractionWhileFetching;
 @property (assign) BOOL autoCompleteTableAppearsAsKeyboardAccessory; //if set to TRUE, the autocomplete table will appear as a keyboard input accessory view rather than a drop down.
+@property (assign) BOOL shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows; // default is TRUE
 
 
 @property (assign) BOOL autoCompleteTableViewHidden;

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -383,7 +383,9 @@ withAutoCompleteString:(NSString *)string
 
 - (void) finishedSearching
 {
-    [self resignFirstResponder];
+    if (self.shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows) {
+        [self resignFirstResponder];
+    }
 }
 
 - (BOOL)resignFirstResponder
@@ -477,6 +479,7 @@ withAutoCompleteString:(NSString *)string
     [self setSortAutoCompleteSuggestionsByClosestMatch:YES];
     [self setApplyBoldEffectToAutoCompleteSuggestions:YES];
     [self setShowTextFieldDropShadowWhenAutoCompleteTableIsOpen:YES];
+    [self shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows:YES];
     [self setAutoCompleteRowHeight:40];
     [self setAutoCompleteFontSize:13];
     [self setMaximumNumberOfAutoCompleteRows:3];


### PR DESCRIPTION
New property `shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows` to specify if the `MLPAutoCompleteTextField` should call `-(void)resignFirstResponder` in `- (void) finishedSearching` . Default is `YES`.
