### PR TITLE
Fixed property issue for resigning first responder

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -479,7 +479,7 @@ withAutoCompleteString:(NSString *)string
     [self setSortAutoCompleteSuggestionsByClosestMatch:YES];
     [self setApplyBoldEffectToAutoCompleteSuggestions:YES];
     [self setShowTextFieldDropShadowWhenAutoCompleteTableIsOpen:YES];
-    [self shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows:YES];
+    [self setShouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows:YES];
     [self setAutoCompleteRowHeight:40];
     [self setAutoCompleteFontSize:13];
     [self setMaximumNumberOfAutoCompleteRows:3];


### PR DESCRIPTION
I changed the code to use the setter method for setting the shouldResignFirstResponderFromKeyboardAfterSelectionOfAutoCompleteRows property
