### PR TITLE
Fixed version number in podspec and readme to match most recent tag

### DIFF
--- a/MLPAutoCompleteTextField.podspec
+++ b/MLPAutoCompleteTextField.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "MLPAutoCompleteTextField"
-  s.version      = "1.5"
+  s.version      = "1.6"
   s.summary      = "UITextfield subclass with autocomplete menu."
   s.homepage     = "https://github.com/EddyBorja/MLPAutoCompleteTextField"
   s.license      = { :type => 'MIT', :file => 'MIT_LICENSE.md' }
   s.author       = { "Eddy Borja" => "eddyborja@gmail.com" }
-  s.source       = { :git => "https://github.com/EddyBorja/MLPAutoCompleteTextField.git", :tag => "1.5" } 
+  s.source       = { :git => "https://github.com/EddyBorja/MLPAutoCompleteTextField.git", :tag => "1.6" } 
   s.platform     = :ios, '5.0'
   s.source_files = 'MLPAutoCompleteTextField', 'MLPAutoCompleteTextField/**/*.{h,m}'
   s.public_header_files = 'MLPAutoCompleteTextField/**/*.h'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ About
 ---------
 _MLPAutoCompleteTextField_ is a subclass of _UITextField_ that behaves like a typical _UITextField_ with one notable exception: it manages a drop down table of autocomplete suggestions that update as the user types. Its behavior may remind you of Google's autocomplete search feature. As of version 1.3 there is also support for showing the autocomplete table as an accessory view of the keyboard.
 
-From version 1.5 and above _MLPAutoCompleteTextField_ is compatible with iOS 5.0 or greater. 
+From version 1.6 and above _MLPAutoCompleteTextField_ is compatible with iOS 5.0 or greater.
 
 ####Example:
   >A user is required to enter a long and complicated chemical name into a textfield. With an autocomplete textfield, chemical names that closely match her entered string can be displayed as she types, and if she sees the chemical name she was thinking of she can select it and have it entered into the textfield automatically. This reduces the amount of typing she has to do and helps prevent errors. All this can occur within a single view and without the need for a search tableview controller.
@@ -18,15 +18,15 @@ Usage
 ---------
 The goal for _MLPAutoCompleteTextField_ is to create an autocomplete textfield that is quick and easy to use, yet eminently customizable. To get a working _MLPAutoCompleteTextField_ instance, ensure you have done the following:
 
-0. Add the _MLPAutoCompleteTextField_, _NSString+Levenshtein_, _MLPAutoCompletionObject.h_, _MLPAutoCompleteDataSource_ and _MLPAutoCompleteTextFieldDelegate_ files into your project (should have seven files in total). 
+0. Add the _MLPAutoCompleteTextField_, _NSString+Levenshtein_, _MLPAutoCompletionObject.h_, _MLPAutoCompleteDataSource_ and _MLPAutoCompleteTextFieldDelegate_ files into your project (should have seven files in total).
 
 1. Have an _MLPAutoCompleteTextField_ instance allocated and initialized within some view.
 
-2. Set the textfield's "autoCompleteDataSource" property to a valid object that implements the required methods of the _MLPAutoCompleteTextFieldDataSource_ protocol. Note that the method "autoCompleteTextField:possibleCompletionsForString:" is the method you use to return possible completions for the textfield's currently entered string. This method is expected to return either an array of _NSString_, or an array of objects conforming to the _MLPAutoCompletionObject_ protocol, or a mix of both. This method is also called asynchronously. 
+2. Set the textfield's "autoCompleteDataSource" property to a valid object that implements the required methods of the _MLPAutoCompleteTextFieldDataSource_ protocol. Note that the method "autoCompleteTextField:possibleCompletionsForString:" is the method you use to return possible completions for the textfield's currently entered string. This method is expected to return either an array of _NSString_, or an array of objects conforming to the _MLPAutoCompletionObject_ protocol, or a mix of both. This method is also called asynchronously.
 
 3. _(Optional)_ Set the textfield's "autoCompleteDelegate" property to a valid object that implements the methods of the _MLPAutoCompleteTextFieldDelegate_ protocol for further customization options.
 
-You should now have a working _MLPAutoCompleteTextField_ at this point. 
+You should now have a working _MLPAutoCompleteTextField_ at this point.
 
 
 Autocomplete as a Keyboard Input Accessory
@@ -42,7 +42,7 @@ CocoaPods are the best way to manage library dependencies in Objective-C project
 Learn more at http://cocoapods.org
 
 Add this to your podfile to add the MLPAutoCompleteTextField to your project.
-`pod 'MLPAutoCompleteTextField', '~> 1.5'`
+`pod 'MLPAutoCompleteTextField', '~> 1.6'`
 
 
 
@@ -54,15 +54,15 @@ The _MLPAutoCompleteTextField_ sorting of autocomplete strings is powered by the
 
 When a datasource passes an array of strings to an _MLPAutoCompleteTextField_, the textfield sorts the strings according to edit distance and displays this list of autocomplete suggestions.
 
-**Used responsibly**, we hope the _MLPAutoCompleteTextField_ will open up new design possibilities for developers of all origins and skill levels. 
+**Used responsibly**, we hope the _MLPAutoCompleteTextField_ will open up new design possibilities for developers of all origins and skill levels.
 
 :D
 
 Performance
 ---------
-_MLPAutoCompleteTextField_ uses a multi-threaded approach to it's sorting of autocomplete strings so that the main thread is never blocked and the UI stays 100% responsive. 
+_MLPAutoCompleteTextField_ uses a multi-threaded approach to it's sorting of autocomplete strings so that the main thread is never blocked and the UI stays 100% responsive.
 
-Keep in mind that although you can pass an ungodly amount of strings in an array to the _MLPAutoCompleteTextField_ at once, sorting performance will suffer directly related to the number of strings you give (we're talking on the magnitude of thousands of strings). If performance is suffering, you should find ways to reduce the amount of strings you pass to the _MLPAutoCompleteTextField_ when it asks you for them. (For example, if you assume a user will always know the first letter of a word correctly, you may choose to only send an array of words that start with that letter or even close to that letter on the keyboard, rather than every single possible word you have). 
+Keep in mind that although you can pass an ungodly amount of strings in an array to the _MLPAutoCompleteTextField_ at once, sorting performance will suffer directly related to the number of strings you give (we're talking on the magnitude of thousands of strings). If performance is suffering, you should find ways to reduce the amount of strings you pass to the _MLPAutoCompleteTextField_ when it asks you for them. (For example, if you assume a user will always know the first letter of a word correctly, you may choose to only send an array of words that start with that letter or even close to that letter on the keyboard, rather than every single possible word you have).
 
 
 Known Issues
@@ -80,12 +80,12 @@ What to Expect in Future Updates
 
 + _Weighted Suggestions_: In some cases, there may exist multiple autocomplete strings that are all equally possible completions for the current entered incomplete string. In current versions, the user will simply have to keep typing a few more characters to further narrow down the autocomplete suggestions to float the most probable string to the top of the autocomplete list.
 
-  However, in the future you can expect to see a sort of "weighting" or "ranking" system, which will allow you to favor some strings over others by assigning a number to them. Strings with higher weight will appear closer to the top of the list of autocomplete suggestions. So even though a group of strings are all equally possible completions for a given incomplete string, the ones with higher weight are deemed as being the "more probable" matches and will be sorted accordingly. 
+  However, in the future you can expect to see a sort of "weighting" or "ranking" system, which will allow you to favor some strings over others by assigning a number to them. Strings with higher weight will appear closer to the top of the list of autocomplete suggestions. So even though a group of strings are all equally possible completions for a given incomplete string, the ones with higher weight are deemed as being the "more probable" matches and will be sorted accordingly.
 
-  This should further reduce the number of characters a user has to type. 
+  This should further reduce the number of characters a user has to type.
 
 
-+ _String Hiding_: If an autocomplete suggestion is of such poor quality that it has nothing in common at all with the user's currently entered string, then there may be a built in option to not display this suggestion at all. 
++ _String Hiding_: If an autocomplete suggestion is of such poor quality that it has nothing in common at all with the user's currently entered string, then there may be a built in option to not display this suggestion at all.
 
 + _Tokenized Bolding_: If a user has entered a string such as "Grate White Sha", and there is an autocomplete suggestion called "Great White Shark", then in the suggestion the word "Great" should be in bold, the word "White" should be regular, and the work "Shark" should have the "rk" bolded. This behaves more like Google's autocomplete. (A user can choose the reverse behavior too).
 
@@ -139,9 +139,9 @@ Credits
 
 _MLPAutoCompleteTextField_ was written by Eddy Borja, at Mainloop LLC.
 
-_NSString+Levenshtein_ category extension was written by Mark Aufflick. 
+_NSString+Levenshtein_ category extension was written by Mark Aufflick.
 
-If you make use of _MLPAutoCompleteTextField_, tell us about it! 
+If you make use of _MLPAutoCompleteTextField_, tell us about it!
 Feel free to leave comments, likes, hatemail, etc at hello@mainloop.us
 
 
@@ -154,4 +154,3 @@ Be sure to check out these other libraries:
 [UIColor+MLPFlatColors](https://github.com/EddyBorja/UIColor-MLPFlatColors)<br />
 [MLPAccessoryBadge](https://github.com/EddyBorja/MLPAccessoryBadge)<br />
 [EBPhotoPages Gallery](https://github.com/EddyBorja/EBPhotoPages)<br />
-


### PR DESCRIPTION
Hi there,

I have bumped the version numbers as mentioned to the most recent tag.
Sorry for also removing some trailing whitespaces in the readme. I did not recognize that my editor was doing this.

Cheers,
Tom 
