### PR TITLE
removes the LLVM "unused variable" warnings

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -601,7 +601,10 @@ withAutoCompleteString:(NSString *)string
     if(self.reuseIdentifier){
         [self unregisterAutoCompleteCellForReuseIdentifier:self.reuseIdentifier];
     }
-    BOOL classSettingSupported = [self.autoCompleteTableView respondsToSelector:@selector(registerClass:forCellReuseIdentifier:)];
+    
+    BOOL classSettingSupported = NO;
+    classSettingSupported = [self.autoCompleteTableView respondsToSelector:@selector(registerClass:forCellReuseIdentifier:)];
+    
     NSAssert(classSettingSupported, @"Unable to set class for cell for autocomplete table, in iOS 5.0 you can set a custom NIB for a reuse identifier to get similar functionality.");
     [self.autoCompleteTableView registerClass:cellClass forCellReuseIdentifier:reuseIdentifier];
     [self setReuseIdentifier:reuseIdentifier];
@@ -931,7 +934,10 @@ withAutoCompleteString:(NSString *)string
     if(!self.isCancelled){
         
         if(suggestions.count){
-            NSObject *firstObject = suggestions[0];
+            
+            NSObject *firstObject = nil;
+            firstObject = suggestions[0];
+            
             NSAssert([firstObject isKindOfClass:[NSString class]] ||
                      [firstObject conformsToProtocol:@protocol(MLPAutoCompletionObject)],
                      @"MLPAutoCompleteTextField expects an array with objects that are either strings or conform to the MLPAutoCompletionObject protocol for possible completions.");


### PR DESCRIPTION
Removes the "unused variable" warnings caused by the NSAssert macro. 
For clarity's sake, explicit declaration has been chosen over the __unused attribute.
Closes issue #54.
