### PR TITLE
fixed issue with not yet set autoCompleteDelegate used in the initialiser

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -117,10 +117,13 @@ static NSString *kDefaultAutoCompleteCellIdentifier = @"_DefaultAutoCompleteCell
     
     UITableView *newTableView = [self newAutoCompleteTableViewForTextField:self];
     [self setAutoCompleteTableView:newTableView];
-    
-    [self styleAutoCompleteTableForBorderStyle:self.borderStyle];
 }
 
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    [self styleAutoCompleteTableForBorderStyle:self.borderStyle];
+}
 
 #pragma mark - Notifications and KVO
 


### PR DESCRIPTION
The IBOutlet autoCompleteDelegate is accessed from the initializer (```init-> initialize-> styleAutoCompleteTableForBorderStyle:```), but the outlets are not set while the designated initializer chain is called, so following delegate method will never get called while the class is initializing 
```objc
- (BOOL)autoCompleteTextField:(MLPAutoCompleteTextField *)textField
    shouldStyleAutoCompleteTableView:(UITableView *)autoCompleteTableView
                      forBorderStyle:(UITextBorderStyle)borderStyle;
```
I moved the call to the ```styleAutoCompleteTableForBorderStyle:``` in the ```awakeFromNib``` method, where the outlets are set.
