### PR TITLE
Add a autoCompleteTableSizeOffset to change the size of the

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
@@ -62,6 +62,7 @@
 @property (assign) CGFloat autoCompleteRowHeight;
 @property (nonatomic, assign) CGRect autoCompleteTableFrame;
 @property (assign) CGSize autoCompleteTableOriginOffset;
+@property (assign) CGSize autoCompleteTableSizeOffset;
 @property (assign) CGFloat autoCompleteTableCornerRadius; //only applies for drop down style autocomplete tables.
 @property (nonatomic, assign) UIEdgeInsets autoCompleteContentInsets;
 @property (nonatomic, assign) UIEdgeInsets autoCompleteScrollIndicatorInsets;

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -832,6 +832,8 @@ withAutoCompleteString:(NSString *)string
     
     frame.origin.x += textField.autoCompleteTableOriginOffset.width;
     frame.origin.y += textField.autoCompleteTableOriginOffset.height;
+    frame.size.height += textField.autoCompleteTableSizeOffset.height;
+    frame.size.width += textField.autoCompleteTableSizeOffset.width;
     frame = CGRectInset(frame, 1, 0);
     
     return frame;


### PR DESCRIPTION
At the moment there is no way to change the size of the autoCompleteTableView.
I added aN offset on the size of the table view like you have done with the origin offset.
If you don’t see a use case where it is useful, tell me and I can show you.