### PR TITLE
Fetch after becoming first responder, resolves issue with fetching old results if clearsOnBeginEditing is true.

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
@@ -29,6 +29,8 @@
 
 @interface MLPAutoCompleteTextField : UITextField <UITableViewDataSource, UITableViewDelegate, MLPAutoCompleteSortOperationDelegate, MLPAutoCompleteFetchOperationDelegate>
 
+@property (assign) IBInspectable BOOL styleAutoCompleteTable;
+
 + (NSString *) accessibilityLabelForIndexPath:(NSIndexPath *)indexPath;
 
 @property (strong, readonly) UITableView *autoCompleteTableView;

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -102,6 +102,8 @@ static NSString *kDefaultAutoCompleteCellIdentifier = @"_DefaultAutoCompleteCell
 
 - (void)initialize
 {
+    self.styleAutoCompleteTable = true;
+    
     [self beginObservingKeyPathsAndNotifications];
     
     [self setDefaultValuesForVariables];
@@ -641,6 +643,10 @@ withAutoCompleteString:(NSString *)string
 
 - (void)styleAutoCompleteTableForBorderStyle:(UITextBorderStyle)borderStyle
 {
+    if (!self.styleAutoCompleteTable) {
+        return;
+    }
+    
     if([self.autoCompleteDelegate respondsToSelector:@selector(autoCompleteTextField:shouldStyleAutoCompleteTableView:forBorderStyle:)]){
         if(![self.autoCompleteDelegate autoCompleteTextField:self
                             shouldStyleAutoCompleteTableView:self.autoCompleteTableView

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -302,6 +302,10 @@ withAutoCompleteString:(NSString *)string
     NSString *autoCompleteString = selectedCell.textLabel.text;
     self.text = autoCompleteString;
     
+    if (indexPath.row > [self.autoCompleteSuggestions count]) {
+        return;
+    }
+    
     id<MLPAutoCompletionObject> autoCompleteObject = self.autoCompleteSuggestions[indexPath.row];
     if(![autoCompleteObject conformsToProtocol:@protocol(MLPAutoCompletionObject)]){
         autoCompleteObject = nil;

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -372,12 +372,14 @@ withAutoCompleteString:(NSString *)string
 {
     [self saveCurrentShadowProperties];
     
+    bool didBecome = [super becomeFirstResponder];
+    
     if(self.showAutoCompleteTableWhenEditingBegins ||
        self.autoCompleteTableAppearsAsKeyboardAccessory){
         [self fetchAutoCompleteSuggestions];
     }
     
-    return [super becomeFirstResponder];
+    return didBecome;
 }
 
 - (void) finishedSearching


### PR DESCRIPTION
If clearsOnEditingDidBegin is true and showAutoCompleteTableWhenEditingBegins is also true, the current implementation will fetch results for the text that was in the field before being cleared when it is tapped. 

This is a fix for that issue.