### PR TITLE
add attachmentView to float

### DIFF
--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.h
@@ -31,6 +31,8 @@
 
 + (NSString *) accessibilityLabelForIndexPath:(NSIndexPath *)indexPath;
 
+@property (nonatomic, strong) UIView* attachmentView;
+
 @property (strong, readonly) UITableView *autoCompleteTableView;
 
 // all delegates and datasources should be weak referenced

--- a/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
+++ b/MLPAutoCompleteTextField/MLPAutoCompleteTextField.m
@@ -449,8 +449,13 @@ withAutoCompleteString:(NSString *)string
         [rootView insertSubview:self.autoCompleteTableView
                    belowSubview:self];
 #else
-        [self.superview insertSubview:self.autoCompleteTableView
-                         belowSubview:self];
+        if (self.attachmentView) {
+            [self.attachmentView addSubview:self.autoCompleteTableView];
+            [self.attachmentView bringSubviewToFront:self.autoCompleteTableView];
+        } else {
+            [self.superview insertSubview:self.autoCompleteTableView
+                             belowSubview:self];
+        }
 #endif
         [self.autoCompleteTableView setUserInteractionEnabled:YES];
         if(self.showTextFieldDropShadowWhenAutoCompleteTableIsOpen){
@@ -843,7 +848,11 @@ withAutoCompleteString:(NSString *)string
     if (CGRectGetWidth(self.autoCompleteTableFrame) > 0){
         frame = self.autoCompleteTableFrame;
     } else {
-        frame = textField.frame;
+        if (self.attachmentView) {
+            frame = [self.attachmentView convertRect:textField.bounds fromView:textField];
+        } else {
+            frame = textField.frame;
+        }
         frame.origin.y += textField.frame.size.height;
     }
     


### PR DESCRIPTION
Set the attachmentView property is the containerview(sample:superview, superview[.superview...].superview, UIScorllView, UITableView, UICollectionView, etc.). The pop menu should be show at front and fix MLPAutoCompleteTextField at UITableViewCell bug.


这个合并请求是添加一个attachmentView属性，只要设置attachmentView为MLPAutoCompleteTextField容器view（可以是textfield的superview或者UIScrollView，UITableView，UICollectionView等），就可以修复在UITableViewCell使用MLPAutoCompleteTextField的bug。